### PR TITLE
Use floating pragmas instead of fixed

### DIFF
--- a/messagelib/contracts/Executor.sol
+++ b/messagelib/contracts/Executor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import { Proxied } from "hardhat-deploy/solc_0.8/proxy/Proxied.sol";

--- a/messagelib/contracts/ExecutorFeeLib.sol
+++ b/messagelib/contracts/ExecutorFeeLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/messagelib/contracts/PriceFeed.sol
+++ b/messagelib/contracts/PriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { Proxied } from "hardhat-deploy/solc_0.8/proxy/Proxied.sol";

--- a/messagelib/contracts/Treasury.sol
+++ b/messagelib/contracts/Treasury.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/messagelib/contracts/uln/LzExecutor.sol
+++ b/messagelib/contracts/uln/LzExecutor.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/messagelib/contracts/uln/dvn/DVN.sol
+++ b/messagelib/contracts/uln/dvn/DVN.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { ILayerZeroUltraLightNodeV2 } from "@layerzerolabs/lz-evm-v1-0.7/contracts/interfaces/ILayerZeroUltraLightNodeV2.sol";
 

--- a/messagelib/contracts/uln/dvn/DVNFeeLib.sol
+++ b/messagelib/contracts/uln/dvn/DVNFeeLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Transfer } from "@layerzerolabs/lz-evm-protocol-v2/contracts/libs/Transfer.sol";

--- a/messagelib/contracts/uln/dvn/adapters/CCIP/CCIPDVNAdapter.sol
+++ b/messagelib/contracts/uln/dvn/adapters/CCIP/CCIPDVNAdapter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { IRouterClient } from "@chainlink/contracts-ccip/src/v0.8/ccip/interfaces/IRouterClient.sol";
 import { CCIPReceiver } from "@chainlink/contracts-ccip/src/v0.8/ccip/applications/CCIPReceiver.sol";

--- a/messagelib/contracts/uln/dvn/adapters/CCIP/CCIPDVNAdapterFeeLib.sol
+++ b/messagelib/contracts/uln/dvn/adapters/CCIP/CCIPDVNAdapterFeeLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { DVNAdapterFeeLibBase } from "../DVNAdapterFeeLibBase.sol";
 

--- a/messagelib/contracts/uln/dvn/adapters/DVNAdapterBase.sol
+++ b/messagelib/contracts/uln/dvn/adapters/DVNAdapterBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { BytesLib } from "solidity-bytes-utils/contracts/BytesLib.sol";

--- a/messagelib/contracts/uln/dvn/adapters/DVNAdapterFeeLibBase.sol
+++ b/messagelib/contracts/uln/dvn/adapters/DVNAdapterFeeLibBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { IDVNAdapterFeeLib } from "../../interfaces/IDVNAdapterFeeLib.sol";
 

--- a/messagelib/contracts/uln/dvn/adapters/axelar/AxelarDVNAdapter.sol
+++ b/messagelib/contracts/uln/dvn/adapters/axelar/AxelarDVNAdapter.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { AxelarExecutable } from "@axelar-network/axelar-gmp-sdk-solidity/contracts/executable/AxelarExecutable.sol";
 import { IAxelarGasService } from "@axelar-network/axelar-gmp-sdk-solidity/contracts/interfaces/IAxelarGasService.sol";

--- a/messagelib/contracts/uln/dvn/adapters/axelar/AxelarDVNAdapterFeeLib.sol
+++ b/messagelib/contracts/uln/dvn/adapters/axelar/AxelarDVNAdapterFeeLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { DVNAdapterFeeLibBase } from "../DVNAdapterFeeLibBase.sol";
 

--- a/messagelib/contracts/uln/uln301/ReceiveUln301.sol
+++ b/messagelib/contracts/uln/uln301/ReceiveUln301.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 

--- a/messagelib/contracts/uln/uln301/SendUln301.sol
+++ b/messagelib/contracts/uln/uln301/SendUln301.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { Packet } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol";
 

--- a/messagelib/contracts/uln/uln301/TreasuryFeeHandler.sol
+++ b/messagelib/contracts/uln/uln301/TreasuryFeeHandler.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/messagelib/contracts/uln/uln302/ReceiveUln302.sol
+++ b/messagelib/contracts/uln/uln302/ReceiveUln302.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { PacketV1Codec } from "@layerzerolabs/lz-evm-protocol-v2/contracts/messagelib/libs/PacketV1Codec.sol";
 import { SetConfigParam } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol";

--- a/messagelib/contracts/uln/uln302/SendUln302.sol
+++ b/messagelib/contracts/uln/uln302/SendUln302.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { Packet } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ISendLib.sol";
 import { SetConfigParam } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/IMessageLibManager.sol";

--- a/oapp/test/mocks/ExecutorFeeLibMock.sol
+++ b/oapp/test/mocks/ExecutorFeeLibMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { ExecutorFeeLib } from "@layerzerolabs/lz-evm-messagelib-v2/contracts/ExecutorFeeLib.sol";
 

--- a/protocol/contracts/EndpointV2.sol
+++ b/protocol/contracts/EndpointV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/protocol/contracts/EndpointV2Alt.sol
+++ b/protocol/contracts/EndpointV2Alt.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/protocol/contracts/messagelib/BlockedMessageLib.sol
+++ b/protocol/contracts/messagelib/BlockedMessageLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { ERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 

--- a/protocol/contracts/messagelib/SimpleMessageLib.sol
+++ b/protocol/contracts/messagelib/SimpleMessageLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LZBL-1.2
 
-pragma solidity 0.8.22;
+pragma solidity ^0.8.22;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";


### PR DESCRIPTION
Fixed pragmas limit compatibility with other codebases (say, using solidity 0.8.23 or future compiler versions yet to come out).

Floating pragmas do not change the deployment version, but allow more robust integration testing locally before running mainnet fork tests. Would help unblock us as we're developing on a different compiler version. No downside or functionality changes, just increases compatibility ranges.