### PR TITLE
Raise executor msg.value cap and add func to allow user configuration

### DIFF
--- a/oapp/test/TestHelper.sol
+++ b/oapp/test/TestHelper.sol
@@ -51,8 +51,19 @@ contract TestHelper is Test, OptionsHelper {
 
     uint256 public constant TREASURY_GAS_CAP = 1000000000000;
     uint256 public constant TREASURY_GAS_FOR_FEE_CAP = 100000;
+    
+    uint128 public executorValueCap = 0.1 ether;
 
     function setUp() public virtual {}
+
+    /**
+     * @dev set executorValueCap if more than 0.1 ether is necessary
+     * @dev this must be called prior to setUpEndpoints() if the value is to be used
+     * @param _valueCap amount executor can pass as msg.value to lzReceive()
+     */
+    function setExecutorValueCap(uint128 _valueCap) public {
+        executorValueCap = _valueCap;
+    }
 
     /**
      * @dev setup the endpoints
@@ -173,7 +184,7 @@ contract TestHelper is Test, OptionsHelper {
                         baseGas: 5000,
                         multiplierBps: 10000,
                         floorMarginUSD: 1e10,
-                        nativeCap: 1 gwei
+                        nativeCap: executorValueCap
                     });
 
                     uint128 denominator = priceFeed.getPriceRatioDenominator();


### PR DESCRIPTION
When using TestHelper.sol to mock the LayerZero V2 environment for my tests, I was unable to pass more than 1 gwei to lzReceive() due to the limit imposed on the executor. I believe 1 gwei is far too low, so I raised it to 0.1 ether and added the setExecutorValueCap(uint128) function to TestHelper.sol so the user can adjust this value if their tests require it.