### PR TITLE
Added upgradeable variant of OApp

### DIFF
--- a/oapp/contracts/oapp-upgradeable/OAppCoreUpgradeable.sol
+++ b/oapp/contracts/oapp-upgradeable/OAppCoreUpgradeable.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.22;
+
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { IOAppCore, ILayerZeroEndpointV2 } from "../oapp/interfaces/IOAppCore.sol";
+
+/**
+ * @title OAppCoreUpgradeable
+ * @dev Abstract contract implementing the IOAppCore interface with basic OApp configurations and upgradeability.
+ */
+abstract contract OAppCoreUpgradeable is IOAppCore, OwnableUpgradeable {
+    // The LayerZero endpoint associated with the given OApp
+    ILayerZeroEndpointV2 public endpoint;
+
+    // Mapping to store peers associated with corresponding endpoints
+    mapping(uint32 eid => bytes32 peer) public peers;
+
+    /**
+     * @dev Constructor to initialize the OAppCore with the provided endpoint and owner.
+     * @param _endpoint The address of the LOCAL Layer Zero endpoint.
+     * @param _owner The address of the owner of the OAppCore.
+     */
+    function _initializeOAppCore(address _endpoint, address _owner) internal onlyInitializing {
+        _transferOwnership(_owner);
+        endpoint = ILayerZeroEndpointV2(_endpoint);
+        endpoint.setDelegate(_owner); // @dev By default, the owner is the delegate
+    }
+
+    /**
+     * @notice Sets the peer address (OApp instance) for a corresponding endpoint.
+     * @param _eid The endpoint ID.
+     * @param _peer The address of the peer to be associated with the corresponding endpoint.
+     *
+     * @dev Only the owner/admin of the OApp can call this function.
+     * @dev Indicates that the peer is trusted to send LayerZero messages to this OApp.
+     * @dev Set this to bytes32(0) to remove the peer address.
+     * @dev Peer is a bytes32 to accommodate non-evm chains.
+     */
+    function setPeer(uint32 _eid, bytes32 _peer) public virtual onlyOwner {
+        peers[_eid] = _peer;
+        emit PeerSet(_eid, _peer);
+    }
+
+    /**
+     * @notice Internal function to get the peer address associated with a specific endpoint; reverts if NOT set.
+     * ie. the peer is set to bytes32(0).
+     * @param _eid The endpoint ID.
+     * @return peer The address of the peer associated with the specified endpoint.
+     */
+    function _getPeerOrRevert(uint32 _eid) internal view virtual returns (bytes32) {
+        bytes32 peer = peers[_eid];
+        if (peer == bytes32(0)) revert NoPeer(_eid);
+        return peer;
+    }
+
+    /**
+     * @notice Sets the delegate address for the OApp.
+     * @param _delegate The address of the delegate to be set.
+     *
+     * @dev Only the owner/admin of the OApp can call this function.
+     * @dev Provides the ability for a delegate to set configs, on behalf of the OApp, directly on the Endpoint contract.
+     * @dev Defaults to the owner of the OApp.
+     */
+    function setDelegate(address _delegate) public onlyOwner {
+        endpoint.setDelegate(_delegate);
+    }
+}

--- a/oapp/contracts/oapp-upgradeable/OAppReceiverUpgradeable.sol
+++ b/oapp/contracts/oapp-upgradeable/OAppReceiverUpgradeable.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.22;
+
+import { ILayerZeroReceiver, Origin } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol";
+import { OAppCoreUpgradeable } from "./OAppCoreUpgradeable.sol";
+
+/**
+ * @title OAppReceiverUpgradeable
+ * @dev Abstract upgradeable contract implementing the ILayerZeroReceiver interface and extending OAppCore for OApp
+ * receivers.
+ */
+abstract contract OAppReceiverUpgradeable is ILayerZeroReceiver, OAppCoreUpgradeable {
+    // Custom error message for when the caller is not the registered endpoint/
+    error OnlyEndpoint(address addr);
+
+    // @dev The version of the OAppReceiver implementation.
+    // @dev Version is bumped when changes are made to this contract.
+    uint64 internal constant RECEIVER_VERSION = 1;
+
+    /**
+     * @notice Retrieves the OApp version information.
+     * @return senderVersion The version of the OAppSender.sol contract.
+     * @return receiverVersion The version of the OAppReceiver.sol contract.
+     *
+     * @dev Providing 0 as the default for OAppSender version. Indicates that the OAppSender is not implemented.
+     * ie. this is a SEND only OApp.
+     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions.
+     */
+    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {
+        return (0, RECEIVER_VERSION);
+    }
+
+    /**
+     * @notice Checks if the path initialization is allowed based on the provided origin.
+     * @param origin The origin information containing the source endpoint and sender address.
+     * @return Whether the path has been initialized.
+     *
+     * @dev This indicates to the endpoint that the OApp has enabled msgs for this particular path to be received.
+     * @dev This defaults to assuming if a peer has been set, its initialized.
+     * Can be overridden by the OApp if there is other logic to determine this.
+     */
+    function allowInitializePath(Origin calldata origin) public view virtual returns (bool) {
+        return peers[origin.srcEid] == origin.sender;
+    }
+
+    /**
+     * @notice Retrieves the next nonce for a given source endpoint and sender address.
+     * @dev _srcEid The source endpoint ID.
+     * @dev _sender The sender address.
+     * @return nonce The next nonce.
+     *
+     * @dev The path nonce starts from 1. If 0 is returned it means that there is NO nonce ordered enforcement.
+     * @dev Is required by the off-chain executor to determine the OApp expects msg execution is ordered.
+     * @dev This is also enforced by the OApp.
+     * @dev By default this is NOT enabled. ie. nextNonce is hardcoded to return 0.
+     */
+    function nextNonce(uint32 /*_srcEid*/, bytes32 /*_sender*/) public view virtual returns (uint64 nonce) {
+        return 0;
+    }
+
+    /**
+     * @dev Entry point for receiving messages or packets from the endpoint.
+     * @param _origin The origin information containing the source endpoint and sender address.
+     *  - srcEid: The source chain endpoint ID.
+     *  - sender: The sender address on the src chain.
+     *  - nonce: The nonce of the message.
+     * @param _guid The unique identifier for the received LayerZero message.
+     * @param _message The payload of the received message.
+     * @param _executor The address of the executor for the received message.
+     * @param _extraData Additional arbitrary data provided by the corresponding executor.
+     *
+     * @dev Entry point for receiving msg/packet from the LayerZero endpoint.
+     */
+    function lzReceive(
+        Origin calldata _origin,
+        bytes32 _guid,
+        bytes calldata _message,
+        address _executor,
+        bytes calldata _extraData
+    ) public payable virtual {
+        // Ensures that only the endpoint can attempt to lzReceive() messages to this OApp.
+        if (address(endpoint) != msg.sender) revert OnlyEndpoint(msg.sender);
+
+        // Ensure that the sender matches the expected peer for the source endpoint.
+        if (_getPeerOrRevert(_origin.srcEid) != _origin.sender) revert OnlyPeer(_origin.srcEid, _origin.sender);
+
+        // Call the internal OApp implementation of lzReceive.
+        _lzReceive(_origin, _guid, _message, _executor, _extraData);
+    }
+
+    /**
+     * @dev Internal function to implement lzReceive logic without needing to copy the basic parameter validation.
+     */
+    function _lzReceive(
+        Origin calldata _origin,
+        bytes32 _guid,
+        bytes calldata _message,
+        address _executor,
+        bytes calldata _extraData
+    ) internal virtual;
+}

--- a/oapp/contracts/oapp-upgradeable/OAppSenderUpgradeable.sol
+++ b/oapp/contracts/oapp-upgradeable/OAppSenderUpgradeable.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.22;
+
+import { SafeERC20, IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { MessagingParams, MessagingFee, MessagingReceipt } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import { OAppCoreUpgradeable } from "./OAppCoreUpgradeable.sol";
+
+/**
+ * @title OAppSenderUpgradeable
+ * @dev Abstract upgradeable contract implementing the OAppSender functionality for sending messages to a LayerZero
+ * endpoint.
+ */
+abstract contract OAppSenderUpgradeable is OAppCoreUpgradeable {
+    using SafeERC20 for IERC20;
+
+    // Custom error messages
+    error NotEnoughNative(uint256 msgValue);
+    error LzTokenUnavailable();
+
+    // @dev The version of the OAppSender implementation.
+    // @dev Version is bumped when changes are made to this contract.
+    uint64 internal constant SENDER_VERSION = 1;
+
+    /**
+     * @notice Retrieves the OApp version information.
+     * @return senderVersion The version of the OAppSender.sol contract.
+     * @return receiverVersion The version of the OAppReceiver.sol contract.
+     *
+     * @dev Providing 0 as the default for OAppReceiver version. Indicates that the OAppReceiver is not implemented.
+     * ie. this is a RECEIVE only OApp.
+     * @dev If the OApp uses both OAppSender and OAppReceiver, then this needs to be override returning the correct versions
+     */
+    function oAppVersion() public view virtual returns (uint64 senderVersion, uint64 receiverVersion) {
+        return (SENDER_VERSION, 0);
+    }
+
+    /**
+     * @dev Internal function to interact with the LayerZero EndpointV2.quote() for fee calculation.
+     * @param _dstEid The destination endpoint ID.
+     * @param _message The message payload.
+     * @param _options Additional options for the message.
+     * @param _payInLzToken Flag indicating whether to pay the fee in LZ tokens.
+     * @return fee The calculated MessagingFee for the message.
+     *      - nativeFee: The native fee for the message.
+     *      - lzTokenFee: The LZ token fee for the message.
+     */
+    function _quote(
+        uint32 _dstEid,
+        bytes memory _message,
+        bytes memory _options,
+        bool _payInLzToken
+    ) internal view virtual returns (MessagingFee memory fee) {
+        return
+            endpoint.quote(
+                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _payInLzToken),
+                address(this)
+            );
+    }
+
+    /**
+     * @dev Internal function to interact with the LayerZero EndpointV2.send() for sending a message.
+     * @param _dstEid The destination endpoint ID.
+     * @param _message The message payload.
+     * @param _options Additional options for the message.
+     * @param _fee The calculated LayerZero fee for the message.
+     *      - nativeFee: The native fee.
+     *      - lzTokenFee: The lzToken fee.
+     * @param _refundAddress The address to receive any excess fee values sent to the endpoint.
+     * @return receipt The receipt for the sent message.
+     *      - guid: The unique identifier for the sent message.
+     *      - nonce: The nonce of the sent message.
+     *      - fee: The LayerZero fee incurred for the message.
+     */
+    function _lzSend(
+        uint32 _dstEid,
+        bytes memory _message,
+        bytes memory _options,
+        MessagingFee memory _fee,
+        address _refundAddress
+    ) internal virtual returns (MessagingReceipt memory receipt) {
+        // @dev Push corresponding fees to the endpoint, any excess is sent back to the _refundAddress from the endpoint.
+        uint256 messageValue = _payNative(_fee.nativeFee);
+        if (_fee.lzTokenFee > 0) _payLzToken(_fee.lzTokenFee);
+
+        return
+            // solhint-disable-next-line check-send-result
+            endpoint.send{ value: messageValue }(
+                MessagingParams(_dstEid, _getPeerOrRevert(_dstEid), _message, _options, _fee.lzTokenFee > 0),
+                _refundAddress
+            );
+    }
+
+    /**
+     * @dev Internal function to pay the native fee associated with the message.
+     * @param _nativeFee The native fee to be paid.
+     * @return nativeFee The amount of native currency paid.
+     *
+     * @dev If the OApp needs to initiate MULTIPLE LayerZero messages in a single transaction,
+     * this will need to be overridden because msg.value would contain multiple lzFees.
+     * @dev Should be overridden in the event the LayerZero endpoint requires a different native currency.
+     * @dev Some EVMs use an ERC20 as a method for paying transactions/gasFees.
+     * @dev The endpoint is EITHER/OR, ie. it will NOT support both types of native payment at a time.
+     */
+    function _payNative(uint256 _nativeFee) internal virtual returns (uint256 nativeFee) {
+        if (msg.value != _nativeFee) revert NotEnoughNative(msg.value);
+        return _nativeFee;
+    }
+
+    /**
+     * @dev Internal function to pay the LZ token fee associated with the message.
+     * @param _lzTokenFee The LZ token fee to be paid.
+     *
+     * @dev If the caller is trying to pay in the specified lzToken, then the lzTokenFee is passed to the endpoint.
+     * @dev Any excess sent, is passed back to the specified _refundAddress in the _lzSend().
+     */
+    function _payLzToken(uint256 _lzTokenFee) internal virtual {
+        // @dev Cannot cache the token because it is not immutable in the endpoint.
+        address lzToken = endpoint.lzToken();
+        if (lzToken == address(0)) revert LzTokenUnavailable();
+
+        // Pay LZ token fee by sending tokens to the endpoint.
+        IERC20(lzToken).safeTransferFrom(msg.sender, address(endpoint), _lzTokenFee);
+    }
+}

--- a/oapp/contracts/oapp-upgradeable/OAppUpgradeable.sol
+++ b/oapp/contracts/oapp-upgradeable/OAppUpgradeable.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.22;
+
+// @dev Import the 'MessagingFee' so it's exposed to OApp implementers
+// solhint-disable-next-line no-unused-import
+import { OAppSenderUpgradeable, MessagingFee } from "./OAppSenderUpgradeable.sol";
+// @dev Import the 'Origin' so it's exposed to OApp implementers
+// solhint-disable-next-line no-unused-import
+import { OAppReceiverUpgradeable, Origin } from "./OAppReceiverUpgradeable.sol";
+import { OAppCoreUpgradeable } from "./OAppCoreUpgradeable.sol";
+
+/**
+ * @title OAppUpgradeable
+ * @dev Abstract contract serving as the base for OAppUpgradeable implementation, combining OAppSenderUpgradeable and
+ * OAppReceiverUpgradeable functionality.
+ */
+abstract contract OAppUpgradeable is OAppSenderUpgradeable, OAppReceiverUpgradeable {
+    /**
+     * @dev Initializer for the upgradeable OApp with the provided endpoint and owner.
+     * @param _endpoint The address of the LOCAL LayerZero endpoint.
+     * @param _owner The address of the owner of the OApp.
+     */
+    function initialize(address _endpoint, address _owner) public virtual initializer {
+        _initializeOAppCore(_endpoint, _owner);
+    }
+
+    /**
+     * @notice Retrieves the OApp version information.
+     * @return senderVersion The version of the OAppSender.sol implementation.
+     * @return receiverVersion The version of the OAppReceiver.sol implementation.
+     */
+    function oAppVersion()
+        public
+        pure
+        virtual
+        override(OAppSenderUpgradeable, OAppReceiverUpgradeable)
+        returns (uint64 senderVersion, uint64 receiverVersion)
+    {
+        return (SENDER_VERSION, RECEIVER_VERSION);
+    }
+}

--- a/oapp/contracts/oapp-upgradeable/OAppUpgradeable.sol
+++ b/oapp/contracts/oapp-upgradeable/OAppUpgradeable.sol
@@ -21,7 +21,7 @@ abstract contract OAppUpgradeable is OAppSenderUpgradeable, OAppReceiverUpgradea
      * @param _endpoint The address of the LOCAL LayerZero endpoint.
      * @param _owner The address of the owner of the OApp.
      */
-    function initialize(address _endpoint, address _owner) public virtual initializer {
+    function _initializeOApp(address _endpoint, address _owner) internal virtual onlyInitializing {
         _initializeOAppCore(_endpoint, _owner);
     }
 


### PR DESCRIPTION
We needed the ability to make an upgradeable OApp for our L0 V2 integration, so I refactored OApp to utilize OpenZeppelin's OwnableUpgradeable.sol and the initialize pattern in place of the non-upgradeable Ownable.sol variant.