### PR TITLE
`ILayerZeroEndpointV2.delegates()` view

### DIFF
--- a/packages/layerzero-v2/evm/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol
+++ b/packages/layerzero-v2/evm/protocol/contracts/interfaces/ILayerZeroEndpointV2.sol
@@ -86,4 +86,6 @@ interface ILayerZeroEndpointV2 is IMessageLibManager, IMessagingComposer, IMessa
     function nativeToken() external view returns (address);
 
     function setDelegate(address _delegate) external;
+
+    function delegates(address _oapp) external view returns (address);
 }


### PR DESCRIPTION
Add view to access the public `delegates` mapping through the interface.