### PR TITLE
docs: update dev comment for quoteOFT

### DIFF
--- a/packages/layerzero-v2/evm/oapp/contracts/oft/OFTCore.sol
+++ b/packages/layerzero-v2/evm/oapp/contracts/oft/OFTCore.sol
@@ -97,7 +97,7 @@ abstract contract OFTCore is IOFT, OApp, OAppPreCrimeSimulator, OAppOptionsType3
     }
 
     /**
-     * @notice Provides a quote for OFT-related operations.
+     * @notice Provides the fee breakdown and settings data for an OFT.
      * @param _sendParam The parameters for the send operation.
      * @return oftLimit The OFT limit information.
      * @return oftFeeDetails The details of OFT fees.

--- a/packages/layerzero-v2/evm/oapp/contracts/oft/interfaces/IOFT.sol
+++ b/packages/layerzero-v2/evm/oapp/contracts/oft/interfaces/IOFT.sol
@@ -104,7 +104,7 @@ interface IOFT {
     function sharedDecimals() external view returns (uint8);
 
     /**
-     * @notice Provides a quote for OFT-related operations.
+     * @notice Provides the fee breakdown and settings data for an OFT.
      * @param _sendParam The parameters for the send operation.
      * @return limit The OFT limit information.
      * @return oftFeeDetails The details of OFT fees.


### PR DESCRIPTION
The current wording for the dev comment of `quoteOFT` uses the term `quote` which in LZ's context, could have readers expect its return value(s) needing to be used directly as a msg.value.