### PR TITLE
fix(oapp): Pass initialOwner to Ownable constructor in OAppCore

### DIFF
--- a/packages/layerzero-v2/evm/oapp/contracts/oapp/OAppCore.sol
+++ b/packages/layerzero-v2/evm/oapp/contracts/oapp/OAppCore.sol
@@ -23,7 +23,7 @@ abstract contract OAppCore is IOAppCore, Ownable {
      *
      * @dev The delegate typically should be set as the owner of the contract.
      */
-    constructor(address _endpoint, address _delegate) {
+    constructor(address _endpoint, address _delegate) Ownable(_delegate) {
         endpoint = ILayerZeroEndpointV2(_endpoint);
 
         if (_delegate == address(0)) revert InvalidDelegate();


### PR DESCRIPTION
## Summary
This PR fixes a constructor bug in OAppCore.sol that causes compilation to fail when using it with recent versions of @openzeppelin/contracts.
## The Bug
The OAppCore contract inherits from OpenZeppelin's Ownable.sol. Newer versions of Ownable require an initialOwner address to be passed to their constructor. The OAppCore constructor was missing this call, leading to the following Solidity compiler error:
> ```
> TypeError: No arguments passed to the base constructor. Specify the arguments or mark "OAppCore" as abstract.
> --> contracts/oapp/OAppCore.sol
> |
> 16 | abstract contract OAppCore is IOAppCore, Ownable {
> | ^
> Note: Base constructor parameters:
> --> @openzeppelin/contracts/access/Ownable.sol:38:16:
> |
> 38 | constructor(address initialOwner) {
> | ^^^^^^^^^^^^^^^^^^^^^^
> ```
This issue occurs because of a version mismatch between the OAppCore implementation and its Ownable dependency, which is resolved to a newer, incompatible version during npm install.
## The Fix
This PR resolves the issue by explicitly calling the Ownable constructor from the OAppCore constructor, passing the _delegate address as the initialOwner. This aligns with the contract's documentation, which states that the delegate should typically be the owner.
The change is a single line in packages/layerzero-v2/evm/oapp/contracts/oapp/OAppCore.sol:
## Apply to OAppCore.sol
This small change makes the oapp module compatible with modern OpenZeppelin contract versions and resolves the compilation failure, allowing for a much smoother developer experience.