### PR TITLE
Refactor package.json to use Yarn commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,18 @@
     "packages/**"
   ],
   "scripts": {
-    "clean": "$npm_execpath workspaces foreach --all run clean",
-    "build": "$npm_execpath workspaces foreach --all run build",
-    "test": "$npm_execpath workspaces foreach --all run test"
+    /* * Use simpler Yarn workspace commands.
+     * `yarn workspaces foreach` (or just `yarn clean`) is usually cleaner.
+     * We use `yarn workspaces foreach` for explicit clarity across all packages.
+     */
+    "clean": "yarn workspaces foreach --all run clean",
+    "build": "yarn workspaces foreach --all run build",
+    "test": "yarn workspaces foreach --all run test"
   },
   "resolutions": {
+    /* * Force specific versions for transitive dependencies to ensure consistency and stability. 
+     * Kept necessary resolutions for critical dev tools. 
+     */
     "@typechain/hardhat": "^9.1.0",
     "aptos": "^1.19.0",
     "ethereumjs-abi": "0.6.8",
@@ -20,13 +27,20 @@
     "typescript": "~5.1.3"
   },
   "devDependencies": {
+    /* * Development dependencies only.
+     * solhint resolution is handled above, so it is removed here if not explicitly needed.
+     */
     "@layerzerolabs/prettier-config-next": "^2.0.1",
     "@layerzerolabs/solhint-config": "^2.0.1",
     "prettier": "^3.1.0",
-    "rimraf": "^5.0.5",
-    "solhint": "^4.0.0"
+    "rimraf": "^5.0.5"
+    /* 'solhint' entry is removed as it's defined in resolutions above */
   },
   "dependenciesMeta": {
+    /* * Yarn PnP configuration: 'unplugged: true' tells Yarn to use a traditional 
+     * node_modules structure for these packages, often required for tools 
+     * that rely on file system access (e.g., Solidity artifacts). 
+     */
     "@axelar-network/axelar-gmp-sdk-solidity": {
       "unplugged": true
     },


### PR DESCRIPTION
Updated workspace commands to use Yarn for better clarity and consistency. Removed 'solhint' from devDependencies as it's defined in resolutions.