### PR TITLE
Fix typo: remove duplicate 'the' in UlnOptions.sol

### DIFF
--- a/packages/layerzero-v2/evm/messagelib/contracts/uln/libs/UlnOptions.sol
+++ b/packages/layerzero-v2/evm/messagelib/contracts/uln/libs/UlnOptions.sol
@@ -50,7 +50,7 @@ library UlnOptions {
 
                     // workerId must equal to the lastWorkerId for the first option
                     // so it is always skipped in the first option
-                    // this operation slices out options whenever the the scan finds a different workerId
+                    // this operation slices out options whenever the scan finds a different workerId
                     if (lastWorkerId == 0) {
                         lastWorkerId = workerId;
                     } else if (workerId != lastWorkerId) {


### PR DESCRIPTION
## Summary
- Fixed a typo in the comment at line 53 of UlnOptions.sol where 'the the' was changed to 'the'

## Test plan
- No functional changes, only comment fix