### PR TITLE
Fix typo: 'up the the' to 'up to the' in IOFT.sol

### DIFF
--- a/packages/layerzero-v2/evm/oapp/contracts/oft/interfaces/IOFT.sol
+++ b/packages/layerzero-v2/evm/oapp/contracts/oft/interfaces/IOFT.sol
@@ -19,7 +19,7 @@ struct SendParam {
 
 /**
  * @dev Struct representing OFT limit information.
- * @dev These amounts can change dynamically and are up the the specific oft implementation.
+ * @dev These amounts can change dynamically and are up to the specific oft implementation.
  */
 struct OFTLimit {
     uint256 minAmountLD; // Minimum amount in local decimals that can be sent to the recipient.


### PR DESCRIPTION
## Summary
- Fixed a typo in the comment at line 22 of IOFT.sol where 'up the the' was changed to 'up to the'

## Test plan
- No functional changes, only comment fix