### PR TITLE
Fix typo: remove duplicate 'to' in executor_fee_lib.move

### DIFF
--- a/packages/layerzero-v2/aptos/contracts/worker_peripherals/fee_libs/executor_fee_lib_0/sources/executor_fee_lib.move
+++ b/packages/layerzero-v2/aptos/contracts/worker_peripherals/fee_libs/executor_fee_lib_0/sources/executor_fee_lib.move
@@ -139,7 +139,7 @@ module executor_fee_lib_0::executor_fee_lib {
             ordered_execution_option,
         ) = executor_option::unpack_options(options);
 
-        // The total value to to be sent to the destination
+        // The total value to be sent to the destination
         let dst_amount: u128 = 0;
         // The total gas to be used for the transaction
         let lz_receive_gas: u128 = 0;


### PR DESCRIPTION
## Summary
- Fixed a typo in the comment at line 142 of executor_fee_lib.move where 'to to be' was changed to 'to be'

## Test plan
- No functional changes, only comment fix