### PR TITLE
fix: remove ManagingRefs from code_object address in destroy_refs

### DIFF
--- a/packages/layerzero-v2/aptos/contracts/deployer/sources/object_code_deployment.move
+++ b/packages/layerzero-v2/aptos/contracts/deployer/sources/object_code_deployment.move
@@ -188,7 +188,7 @@ module deployer::object_code_deployment {
         let ManagingRefs {
             extend_ref: _,
             arbitrary_signer_enabled: _,
-        } = move_from<ManagingRefs>(publisher_address);
+        } = move_from<ManagingRefs>(code_object);
 
         event::emit(DestroyRefs { object_address: code_object });
     }


### PR DESCRIPTION
destroy_refs incorrectly removed ManagingRefs from the publisher address. The resource is stored under the code_object address, so move_from must use code_object to correctly destroy it